### PR TITLE
Include next function in error middleware

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -11,18 +11,27 @@ app.use(express.json());
 
 app.use('/tasks', taskRoutes);
 
-app.use((error: Error, req: express.Request, res: express.Response) => {
-  if (error instanceof ZodError) {
-    return res
-      .status(400)
-      .json({ message: 'Validation error.', issues: error.format() });
-  }
+app.use(
+  (
+    error: Error,
+    req: express.Request,
+    res: express.Response,
+    next: express.NextFunction,
+  ) => {
+    if (error instanceof ZodError) {
+      return res
+        .status(400)
+        .json({ message: 'Validation error.', issues: error.format() });
+    }
 
-  if (env.NODE_ENV !== 'production') {
-    console.error(error);
-  } else {
-    // TODO: Log error
-  }
+    if (env.NODE_ENV !== 'production') {
+      console.error(error);
+    } else {
+      // TODO: Log error
+    }
 
-  return res.status(500).json({ message: 'Internal server error.' });
-});
+    res.status(500).json({ message: 'Internal server error.' });
+
+    return next(error);
+  },
+);


### PR DESCRIPTION
## Summary
- allow express error middleware to accept `next` and forward errors

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890b45cf8e083269c0bc6e32ef8a656