### PR TITLE
docs: fix clone path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The project follows **Clean Architecture** principles with clear separation of r
 
 #### 1. Clone the Repository
 ```bash
-git clone git@github.com:igorpimentel23/todo-list-node-prisma.git && cd todo-list-backend
+git clone git@github.com:igorpimentel23/todo-list-node-prisma.git && cd todo-list-node-prisma
 ```
 
 #### 2. Copy Environment File


### PR DESCRIPTION
## Summary
- fix directory name in clone instructions

## Testing
- `npx eslint src && echo "Lint passed"`

------
https://chatgpt.com/codex/tasks/task_e_6890b45ebe608326b6f7b2585aa996cf