### PR TITLE
Add task controller test for 404 handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "tsx watch src/server.ts",
     "start": "node build/server.js",
     "build": "tsup src --out-dir build",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest"
   },
   "keywords": [
     "todo",
@@ -37,7 +38,10 @@
     "tsup": "8.5.0",
     "tsx": "4.20.3",
     "typescript": "5.8.3",
-    "typescript-eslint": "8.38.0"
+    "typescript-eslint": "8.38.0",
+    "vitest": "^1.0.0",
+    "supertest": "^6.3.4",
+    "@types/supertest": "^2.0.16"
   },
   "dependencies": {
     "@prisma/client": "6.12.0",

--- a/src/http/controllers/taskController.ts
+++ b/src/http/controllers/taskController.ts
@@ -44,6 +44,9 @@ export const taskController = {
 
       const showTaskUseCase = new ShowTaskUseCase(new PrismaTasksRepository());
       const task = await showTaskUseCase.execute(id);
+      if (!task) {
+        return res.status(404).json({ message: 'Task not found' });
+      }
 
       return res.json(task);
     } catch (error) {

--- a/tests/taskController.spec.ts
+++ b/tests/taskController.spec.ts
@@ -1,0 +1,18 @@
+import request from 'supertest';
+import { describe, it, expect, vi } from 'vitest';
+import { app } from '../src/app';
+import { PrismaTasksRepository } from '../src/repositories/prisma/tasksRepository';
+
+describe('Task Controller', () => {
+  it('should return 404 when task does not exist', async () => {
+    vi.spyOn(PrismaTasksRepository.prototype, 'findById').mockResolvedValue(
+      null,
+    );
+
+    const response = await request(app).get(
+      '/tasks/11111111-1111-1111-1111-111111111111',
+    );
+
+    expect(response.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary
- add vitest/supertest config and test script
- return 404 when task not found
- add test validating 404 from GET `/tasks/:id`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890b460b6cc8326b6361cebfaa1d5bb