### PR TITLE
chore: fix comment punctuation in Prisma schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,4 +1,4 @@
-// This is your Prisma schema file,
+// This is your Prisma schema file.
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {


### PR DESCRIPTION
## Summary
- replace trailing comma with period in Prisma schema comment

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890b458fff883269a4631feae070b51