### PR TITLE
fix: ensure error middleware signature

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -11,18 +11,26 @@ app.use(express.json());
 
 app.use('/tasks', taskRoutes);
 
-app.use((error: Error, req: express.Request, res: express.Response) => {
-  if (error instanceof ZodError) {
-    return res
-      .status(400)
-      .json({ message: 'Validation error.', issues: error.format() });
-  }
+app.use(
+  (
+    error: Error,
+    req: express.Request,
+    res: express.Response,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _next: express.NextFunction,
+  ) => {
+    if (error instanceof ZodError) {
+      return res
+        .status(400)
+        .json({ message: 'Validation error.', issues: error.format() });
+    }
 
-  if (env.NODE_ENV !== 'production') {
-    console.error(error);
-  } else {
-    // TODO: Log error
-  }
+    if (env.NODE_ENV !== 'production') {
+      console.error(error);
+    } else {
+      // TODO: Log error
+    }
 
-  return res.status(500).json({ message: 'Internal server error.' });
-});
+    return res.status(500).json({ message: 'Internal server error.' });
+  },
+);


### PR DESCRIPTION
## Summary
- fix global error handler to use Express' four-argument signature

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890b10e1a1c8326abcefffcbc414a80